### PR TITLE
Fix Authentication and HTTPS on AppEngine

### DIFF
--- a/.github/workflows/Heroku.yml
+++ b/.github/workflows/Heroku.yml
@@ -356,25 +356,6 @@ jobs:
           patch-dependency-tree "root"
           patch-dependency-tree "test-helpers"
 
-      - name: List diff dir
-        working-directory: diff
-        run: ls -la
-
-      - name: Disk usage
-        working-directory: diff
-        run: du -h -d 1
-
-      - name: Disk quota
-        working-directory: diff
-        run: df
-
-      - name: Upload "EVERYTHING" artifact.
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: EVERYTHING
-          path: ${{ github.workspace }}
-
       - name: Merge diffs into a single file (all.dependencies.diff).
         working-directory: diff
         run: |

--- a/.github/workflows/Heroku.yml
+++ b/.github/workflows/Heroku.yml
@@ -615,7 +615,9 @@ jobs:
       - name: Start Backend.
         working-directory: Heroku
         run: |
-          ./gradlew --no-daemon --stacktrace :backend:endpoint:run --args "../../deploy/frontend/static ../../test/fake-data" >backend.log 2>&1 &
+          ./gradlew --no-daemon --stacktrace :backend:endpoint:run \
+            --args="-P:twisterrob.cinema.staticRootFolder=../../deploy/frontend/static -P:twisterrob.cinema.fakeRootFolder=../../test/fake-data" \
+            >backend.log 2>&1 &
           echo "PID_ENDPOINT=$!" | tee --append $GITHUB_ENV
           sleep 10
 

--- a/.github/workflows/Heroku.yml
+++ b/.github/workflows/Heroku.yml
@@ -356,6 +356,25 @@ jobs:
           patch-dependency-tree "root"
           patch-dependency-tree "test-helpers"
 
+      - name: List diff dir
+        working-directory: diff
+        run: ls -la
+
+      - name: Disk usage
+        working-directory: diff
+        run: du -h -d 1
+
+      - name: Disk quota
+        working-directory: diff
+        run: df
+
+      - name: Upload "EVERYTHING" artifact.
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: EVERYTHING
+          path: ${{ github.workspace }}
+
       - name: Merge diffs into a single file (all.dependencies.diff).
         working-directory: diff
         run: |

--- a/Heroku/.idea/runConfigurations/Backend__OGM_.xml
+++ b/Heroku/.idea/runConfigurations/Backend__OGM_.xml
@@ -1,7 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Backend (OGM)" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="net.twisterrob.cinema.cineworld.backend.MainKt" />
-    <module name="Heroku.backend.endpoint.main" />
+    <module name="Cinema-Heroku.backend.endpoint.main" />
+    <option name="PROGRAM_PARAMETERS" value="-P:environment=production" />
+    <shortenClasspath name="NONE" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configurationFile=log4j2.xml,log4j2-endpoint.xml" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/Heroku/.idea/runConfigurations/Backend__OGM_.xml
+++ b/Heroku/.idea/runConfigurations/Backend__OGM_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Backend (OGM)" type="JetRunConfigurationType">
-    <option name="MAIN_CLASS_NAME" value="net.twisterrob.cinema.cineworld.backend.MainKt" />
+    <option name="MAIN_CLASS_NAME" value="io.ktor.server.netty.EngineMain" />
     <module name="Cinema-Heroku.backend.endpoint.main" />
     <shortenClasspath name="NONE" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configurationFile=log4j2.xml,log4j2-endpoint.xml" />

--- a/Heroku/.idea/runConfigurations/Backend__OGM_.xml
+++ b/Heroku/.idea/runConfigurations/Backend__OGM_.xml
@@ -2,7 +2,6 @@
   <configuration default="false" name="Backend (OGM)" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="net.twisterrob.cinema.cineworld.backend.MainKt" />
     <module name="Cinema-Heroku.backend.endpoint.main" />
-    <option name="PROGRAM_PARAMETERS" value="-P:environment=production" />
     <shortenClasspath name="NONE" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configurationFile=log4j2.xml,log4j2-endpoint.xml" />
     <method v="2">

--- a/Heroku/README.md
+++ b/Heroku/README.md
@@ -14,7 +14,7 @@
 
 ### Entry points
 
- * [:backend:endpoint Main.kt](backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt): web server; `backend` for planner, serving `deploy/frontend` folder as content
+ * [:backend:endpoint Main.kt](backend/endpoint/src/main/resources/application.conf): web server; `backend` for planner, serving `deploy/frontend` folder as content
  * `frontend/src/planner/pages/index.html`: root of planner page
  * `frontend/src/planner/scripts/index.js`: root of planner webapp logic
  * [:backend:sync Main.kt](backend/sync/src/main/kotlin/net/twisterrob/cinema/cineworld/sync/Main.kt): scheduled updater for database

--- a/Heroku/backend/endpoint/build.gradle.kts
+++ b/Heroku/backend/endpoint/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 application {
 	publishSlimJar()
-	mainClass.set("net.twisterrob.cinema.cineworld.backend.MainKt")
+	mainClass.set("io.ktor.server.netty.EngineMain")
 	tasks.named<JavaExec>("run") {
 		jvmArgs(
 			"-Dlog4j.configurationFile=log4j2.xml,log4j2-sync.xml"

--- a/Heroku/backend/endpoint/build.gradle.kts
+++ b/Heroku/backend/endpoint/build.gradle.kts
@@ -14,12 +14,12 @@ application {
 		jvmArgs(
 			"-Dlog4j.configurationFile=log4j2.xml,log4j2-sync.xml"
 		)
-		// Can be overridden with `gradlew :backend:endpoint:run --args="<static-folder> <fake-folder>"`.
+		// Can be overridden with `gradlew :backend:endpoint:run --args="-P:twisterrob.cinema.staticRootFolder=<static-folder> -P:twisterrob.cinema.fakeRootFolder=<fake-folder>"`.
 		args(
 			// The folder that :frontend builds into.
-			"../../deploy/frontend/static",
+			"-P:twisterrob.cinema.staticRootFolder=../../deploy/frontend/static",
 			// The folder that is looked at for debug builds for fake data for reproducible testing.
-			"../src/test/fake"
+			"-P:twisterrob.cinema.fakeRootFolder=../src/test/fake"
 		)
 	}
 }

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
@@ -1,5 +1,0 @@
-package net.twisterrob.cinema.cineworld.backend
-
-fun main(vararg args: String) {
-	io.ktor.server.netty.EngineMain.main(args.toList().toTypedArray())
-}

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
@@ -1,29 +1,5 @@
 package net.twisterrob.cinema.cineworld.backend
 
-import io.ktor.server.application.Application
-import io.ktor.server.engine.addShutdownHook
-import io.ktor.server.engine.commandLineEnvironment
-import io.ktor.server.engine.stop
-import io.ktor.server.netty.NettyApplicationEngine
-import net.twisterrob.cinema.cineworld.backend.ktor.configuration
-import net.twisterrob.cinema.cineworld.backend.ktor.daggerApplication
-import java.util.concurrent.TimeUnit
-
 fun main(vararg args: String) {
-	// Same as io.ktor.server.netty.EngineMain.main(args.toList().toTypedArray()), but with extra module:
-	val applicationEnvironment = commandLineEnvironment(args.toList().toTypedArray()) {
-		modules.add {
-			// TODO re-wire to use proper configuration.
-			// Note: can't use YAML because of this lambda, but can use HOCON.
-			configuration()
-		}
-		// Note: because this has to be second, cannot use ktor.application.modules.
-		modules.add(Application::daggerApplication)
-	}
-	val engine = NettyApplicationEngine(applicationEnvironment)
-	engine.addShutdownHook {
-		@Suppress("MagicNumber")
-		engine.stop(3, 5, TimeUnit.SECONDS)
-	}
-	engine.start(true)
+	io.ktor.server.netty.EngineMain.main(args.toList().toTypedArray())
 }

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/Main.kt
@@ -7,7 +7,6 @@ import io.ktor.server.engine.stop
 import io.ktor.server.netty.NettyApplicationEngine
 import net.twisterrob.cinema.cineworld.backend.ktor.configuration
 import net.twisterrob.cinema.cineworld.backend.ktor.daggerApplication
-import java.io.File
 import java.util.concurrent.TimeUnit
 
 fun main(vararg args: String) {
@@ -16,18 +15,7 @@ fun main(vararg args: String) {
 		modules.add {
 			// TODO re-wire to use proper configuration.
 			// Note: can't use YAML because of this lambda, but can use HOCON.
-			val staticContentPath = if (args.isNotEmpty()) args[0] else null
-			val fakeContentPath = if (args.size >= 2) args[1] else null
-			when {
-				staticContentPath != null && fakeContentPath != null ->
-					configuration(staticRootFolder = File(staticContentPath), fakeRootFolder = File(fakeContentPath))
-
-				staticContentPath != null ->
-					configuration(staticRootFolder = File(staticContentPath))
-
-				else ->
-					configuration()
-			}
+			configuration()
 		}
 		// Note: because this has to be second, cannot use ktor.application.modules.
 		modules.add(Application::daggerApplication)

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/app/ApplicationAttributes.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/app/ApplicationAttributes.kt
@@ -7,7 +7,6 @@ import io.ktor.server.routing.RoutingApplicationCall
 import io.ktor.util.AttributeKey
 import io.ktor.util.Attributes
 import net.twisterrob.cinema.cineworld.backend.endpoint.auth.data.CurrentUser
-import java.io.File
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -21,14 +20,6 @@ object ApplicationAttributes {
 	private val DaggerComponentAttribute = AttributeKey<ApplicationComponent>("dagger")
 
 	var Attributes.dagger: ApplicationComponent by requiredKey(DaggerComponentAttribute)
-
-	private val StaticRootFolderAttribute = AttributeKey<File>("staticRootFolder")
-
-	var Attributes.staticRootFolder: File by requiredKey(StaticRootFolderAttribute)
-
-	private val FakeRootFolderAttribute = AttributeKey<File>("fakeRootFolder")
-
-	var Attributes.fakeRootFolder: File by requiredKey(FakeRootFolderAttribute)
 
 	private val CurrentUserAttribute = AttributeKey<CurrentUser>("currentUser")
 

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/AppController.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/AppController.kt
@@ -11,8 +11,8 @@ import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.application
 import io.ktor.server.routing.get
-import net.twisterrob.cinema.cineworld.backend.app.ApplicationAttributes.staticRootFolder
 import net.twisterrob.cinema.cineworld.backend.ktor.RouteController
+import net.twisterrob.cinema.cineworld.backend.ktor.staticRootFolder
 import javax.inject.Inject
 
 /**
@@ -34,7 +34,7 @@ class AppController @Inject constructor(
 		}
 
 		static("/") {
-			staticRootFolder = application.attributes.staticRootFolder
+			staticRootFolder = application.environment.config.staticRootFolder
 			application.log.debug(
 				"""
 					Running static content at / from ${staticRootFolder}

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/TestController.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/TestController.kt
@@ -14,10 +14,10 @@ import io.ktor.server.response.respondFile
 import io.ktor.server.routing.Routing
 import io.ktor.util.pipeline.PipelineContext
 import kotlinx.coroutines.launch
-import net.twisterrob.cinema.cineworld.backend.app.ApplicationAttributes.fakeRootFolder
 import net.twisterrob.cinema.cineworld.backend.ktor.Env
 import net.twisterrob.cinema.cineworld.backend.ktor.RouteController
 import net.twisterrob.cinema.cineworld.backend.ktor.environment
+import net.twisterrob.cinema.cineworld.backend.ktor.fakeRootFolder
 import java.io.File
 import javax.inject.Inject
 
@@ -31,7 +31,7 @@ class TestController @Inject constructor(
 	override fun Routing.registerRoutes() {
 		if (application.environment.config.environment == Env.PRODUCTION) return
 
-		val root = application.attributes.fakeRootFolder
+		val root = application.environment.config.fakeRootFolder
 		application.log.debug(
 			"""
 				Running fake content from ${root}

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/KtorExtensions.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/KtorExtensions.kt
@@ -18,11 +18,12 @@ fun ApplicationCall.absoluteUrl(path: String = "/"): String {
 		// isProduction() to prevent:
 		// > Error 400: redirect_uri_mismatch
 		// > You can't sign in to this app because it doesn't comply with Google's OAuth 2.0 policy.
-		// > redirect_uri: http://cinema.twisterrob.net:6741/auth/google/return
+		// > If you're the app developer, register the redirect URI in the Google Cloud Console.
+		// > Request details: redirect_uri=http://cinema.twisterrob.net:8081/auth/google/return
 		if (port == defaultPort || isProduction()) "" else ":$port"
 	}
 	val protocol = request.origin.scheme
-	return "$protocol://$hostPort$path"
+	return "${protocol}://${hostPort}${path}"
 }
 
 private fun ApplicationCall.isProduction(): Boolean =

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
@@ -3,6 +3,7 @@
 package net.twisterrob.cinema.cineworld.backend.ktor
 
 import io.ktor.server.config.ApplicationConfig
+import java.io.File
 
 enum class Env {
 	PRODUCTION,
@@ -10,7 +11,19 @@ enum class Env {
 	DEVELOPMENT
 }
 
+val ApplicationConfig.app: ApplicationConfig
+	get() = this.config("twisterrob.cinema")
+
 val ApplicationConfig.environment: Env
-	get() = this.propertyOrNull("environment")
-		?.let { Env.valueOf(it.getString().uppercase()) }
-		?: Env.DEVELOPMENT
+	get() = this.app.property("environment")
+		.let { Env.valueOf(it.getString().uppercase()) }
+
+val ApplicationConfig.staticRootFolder: File
+	get() = this.app.property("staticRootFolder")
+		.getString()
+		.let(::File)
+
+val ApplicationConfig.fakeRootFolder: File
+	get() = this.app.property("fakeRootFolder")
+		.getString()
+		.let(::File)

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
@@ -3,6 +3,7 @@
 package net.twisterrob.cinema.cineworld.backend.ktor
 
 import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.MapApplicationConfig
 import java.io.File
 
 enum class Env {
@@ -27,3 +28,9 @@ val ApplicationConfig.fakeRootFolder: File
 	get() = this.app.property("fakeRootFolder")
 		.getString()
 		.let(::File)
+
+fun MapApplicationConfig.putIfAbsent(key: String, value: String) {
+	if (key !in keys()) {
+		put(key, value)
+	}
+}

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/config.kt
@@ -16,18 +16,13 @@ val ApplicationConfig.app: ApplicationConfig
 	get() = this.config("twisterrob.cinema")
 
 val ApplicationConfig.environment: Env
-	get() = this.app.property("environment")
-		.let { Env.valueOf(it.getString().uppercase()) }
+	get() = Env.valueOf(this.app.property("environment").getString().uppercase())
 
 val ApplicationConfig.staticRootFolder: File
-	get() = this.app.property("staticRootFolder")
-		.getString()
-		.let(::File)
+	get() = File(this.app.property("staticRootFolder").getString())
 
 val ApplicationConfig.fakeRootFolder: File
-	get() = this.app.property("fakeRootFolder")
-		.getString()
-		.let(::File)
+	get() = File(this.app.property("fakeRootFolder").getString())
 
 fun MapApplicationConfig.putIfAbsent(key: String, value: String) {
 	if (key !in keys()) {

--- a/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/configuration.kt
+++ b/Heroku/backend/endpoint/src/main/kotlin/net/twisterrob/cinema/cineworld/backend/ktor/configuration.kt
@@ -44,36 +44,26 @@ import kotlinx.html.h2
 import kotlinx.html.head
 import kotlinx.html.pre
 import kotlinx.html.title
-import net.twisterrob.cinema.cineworld.backend.app.ApplicationAttributes.fakeRootFolder
-import net.twisterrob.cinema.cineworld.backend.app.ApplicationAttributes.staticRootFolder
 import net.twisterrob.cinema.cineworld.backend.endpoint.app.App
 import net.twisterrob.cinema.cineworld.backend.endpoint.auth.data.AuthSession
 import net.twisterrob.cinema.cineworld.backend.endpoint.auth.data.UserInfoOpenID.Scopes.email
 import net.twisterrob.cinema.cineworld.backend.endpoint.auth.data.UserInfoOpenID.Scopes.openid
 import net.twisterrob.cinema.cineworld.backend.endpoint.auth.data.UserInfoOpenID.Scopes.profile
-import java.io.File
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 /**
- * @param staticRootFolder for serving static content (`.` is the Heroku project folder when ran from IDEA).
- * @param fakeRootFolder fallback folder for requests for testing (`.` is the Heroku project folder when ran from IDEA).
  * @param oauthHttpClient [HttpClient] to use for OAuth.
  * @param config configuration containing non-hardcoded constants for the server.
  * @see RouteControllerRegistrar
  */
 @Suppress("LongMethod") // TODO find a way to split this up into smaller pieces, while keeping visibility.
 internal fun Application.configuration(
-	staticRootFolder: File = File("./deploy/frontend/static"),
-	fakeRootFolder: File = File("./backend/src/test/fake"),
 	oauthHttpClient: HttpClient = HttpClient(),
 	config: Map<String, Any?> = jacksonObjectMapper()
 		.readValue(App::class.java.getResourceAsStream("/default-env.json")!!)
 ) {
 	log.info("Configuring app as ${environment.config.environment} environment.")
-
-	this.attributes.staticRootFolder = staticRootFolder
-	this.attributes.fakeRootFolder = fakeRootFolder
 
 	install(DefaultHeaders)
 	install(CallLogging)

--- a/Heroku/backend/endpoint/src/main/resources/application.conf
+++ b/Heroku/backend/endpoint/src/main/resources/application.conf
@@ -4,12 +4,13 @@ ktor {
 	}
 	application {
 		modules = [
-			# Cannot use named modules yet because of hacky configuration in Main.kt.
-			# net.twisterrob.cinema.cineworld.backend.ktor.DaggerApplicationKt.daggerApplication
+			net.twisterrob.cinema.cineworld.backend.ktor.ConfigurationKt.configuration
+			net.twisterrob.cinema.cineworld.backend.ktor.DaggerApplicationKt.daggerApplication
 		]
 	}
 }
 
+# These are overridable with -P:path.to.prop=value, see https://ktor.io/docs/configurations.html#command-line.
 twisterrob {
 	cinema {
 		environment = development

--- a/Heroku/backend/endpoint/src/main/resources/application.conf
+++ b/Heroku/backend/endpoint/src/main/resources/application.conf
@@ -1,0 +1,11 @@
+ktor {
+    deployment {
+        port = ${PORT}
+    }
+    application {
+        modules = [
+            # Cannot use named modules yet because of hacky configuration in Main.kt.
+            # net.twisterrob.cinema.cineworld.backend.ktor.DaggerApplicationKt.daggerApplication
+        ]
+    }
+}

--- a/Heroku/backend/endpoint/src/main/resources/application.conf
+++ b/Heroku/backend/endpoint/src/main/resources/application.conf
@@ -9,3 +9,13 @@ ktor {
 		]
 	}
 }
+
+twisterrob {
+	cinema {
+		environment = development
+		# For serving static content (`.` is the Heroku project folder when ran from IDEA).
+		staticRootFolder = ./deploy/frontend/static
+        # Fallback folder for requests for testing (`.` is the Heroku project folder when ran from IDEA).
+		fakeRootFolder = ./backend/src/test/fake
+	}
+}

--- a/Heroku/backend/endpoint/src/main/resources/application.conf
+++ b/Heroku/backend/endpoint/src/main/resources/application.conf
@@ -1,11 +1,11 @@
 ktor {
-    deployment {
-        port = ${PORT}
-    }
-    application {
-        modules = [
-            # Cannot use named modules yet because of hacky configuration in Main.kt.
-            # net.twisterrob.cinema.cineworld.backend.ktor.DaggerApplicationKt.daggerApplication
-        ]
-    }
+	deployment {
+		port = ${PORT}
+	}
+	application {
+		modules = [
+			# Cannot use named modules yet because of hacky configuration in Main.kt.
+			# net.twisterrob.cinema.cineworld.backend.ktor.DaggerApplicationKt.daggerApplication
+		]
+	}
 }

--- a/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/AppFuncTest.kt
+++ b/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/app/AppFuncTest.kt
@@ -4,7 +4,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import net.twisterrob.cinema.cineworld.backend.endpoint.endpointTest
-import net.twisterrob.cinema.cineworld.backend.ktor.configuration
 import net.twisterrob.test.TagFunctional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -18,7 +17,7 @@ class AppFuncTest {
 	 * @see App.Routes.Home
 	 */
 	@Test fun `root serves index html`(@TempDir tempDir: File) = endpointTest(
-		configure = { configuration(staticRootFolder = tempDir) }
+		testConfig = mapOf("twisterrob.cinema.staticRootFolder" to tempDir.absolutePath),
 	) {
 		tempDir.resolve("index.html").writeText("fake index")
 
@@ -29,7 +28,7 @@ class AppFuncTest {
 	}
 
 	@Test fun `index is directly accessible`(@TempDir tempDir: File) = endpointTest(
-		configure = { configuration(staticRootFolder = tempDir) }
+		testConfig = mapOf("twisterrob.cinema.staticRootFolder" to tempDir.absolutePath),
 	) {
 		tempDir.resolve("index.html").writeText("fake index")
 
@@ -40,7 +39,7 @@ class AppFuncTest {
 	}
 
 	@Test fun `other files are directly accessible`(@TempDir tempDir: File) = endpointTest(
-		configure = { configuration(staticRootFolder = tempDir) }
+		testConfig = mapOf("twisterrob.cinema.staticRootFolder" to tempDir.absolutePath),
 	) {
 		tempDir.resolve("other.file").writeText("fake content")
 
@@ -51,7 +50,7 @@ class AppFuncTest {
 	}
 
 	@Test fun `other files in subfolders are directly accessible`(@TempDir tempDir: File) = endpointTest(
-		configure = { configuration(staticRootFolder = tempDir) }
+		testConfig = mapOf("twisterrob.cinema.staticRootFolder" to tempDir.absolutePath),
 	) {
 		tempDir.resolve("sub/folder/other.file").ensureParent().writeText("fake content")
 
@@ -62,7 +61,7 @@ class AppFuncTest {
 	}
 
 	@Test fun `planner serves index html`(@TempDir tempDir: File) = endpointTest(
-		configure = { configuration(staticRootFolder = tempDir) }
+		testConfig = mapOf("twisterrob.cinema.staticRootFolder" to tempDir.absolutePath),
 	) {
 		tempDir.resolve("planner/index.html").ensureParent().writeText("fake index")
 

--- a/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/endpointTest.kt
+++ b/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/endpointTest.kt
@@ -3,12 +3,14 @@ package net.twisterrob.cinema.cineworld.backend.endpoint
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.application.log
+import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.createTestEnvironment
 import io.ktor.server.testing.withApplication
 import net.twisterrob.cinema.cineworld.backend.ktor.ServerLogging
 import net.twisterrob.cinema.cineworld.backend.ktor.configuration
 import net.twisterrob.cinema.cineworld.backend.ktor.daggerApplication
+import net.twisterrob.cinema.cineworld.backend.ktor.putIfAbsent
 import org.slf4j.Logger
 
 /**
@@ -21,11 +23,17 @@ fun endpointTest(
 	configure: Application.() -> Unit = { configuration() },
 	daggerApp: Application.() -> Unit = { daggerApplication() },
 	logLevel: ServerLogging.LogLevel = ServerLogging.LogLevel.ALL,
+	testConfig: Map<String, String> = emptyMap(),
 	test: TestApplicationEngine.() -> Unit
 ) {
 	@Suppress("DEPRECATION") // TODO https://github.com/TWiStErRob/net.twisterrob.cinema/issues/167
 	withApplication(
 		environment = createTestEnvironment {
+			config = MapApplicationConfig(testConfig.entries.map { it.key to it.value }).apply {
+				putIfAbsent("twisterrob.cinema.environment", "test")
+				putIfAbsent("twisterrob.cinema.fakeRootFolder", ".")
+				putIfAbsent("twisterrob.cinema.staticRootFolder", ".")
+			}
 			developmentMode = true
 			val originalLog = log
 			log = object : Logger by originalLog {

--- a/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/endpointTest.kt
+++ b/Heroku/backend/endpoint/src/test/kotlin/net/twisterrob/cinema/cineworld/backend/endpoint/endpointTest.kt
@@ -17,6 +17,7 @@ import org.slf4j.Logger
  * @param configure A call to [configuration], but some tests will need to pass in an optional argument.
  * @param daggerApp A call to [daggerApplication], but some tests may decide to call with a custom [dagger.Component].
  * @param logLevel How much logging should be done.
+ * @param testConfig Configuration overrides for the ktor application. See `src/main/resources/application.conf`.
  * @param test Test code to execute after the application has started up.
  */
 fun endpointTest(

--- a/Heroku/deploy/appengine/src/main/appengine/app.yaml
+++ b/Heroku/deploy/appengine/src/main/appengine/app.yaml
@@ -11,3 +11,6 @@ entrypoint: java -Xmx64M -jar twisterrob-cinema-backend-endpoint.jar static
 env_variables:
   # Used by endpoint and sync. URL of the Neo4J graph database server, including authentication details. e.g. neo4j+s://user:pass@host:1234",
   NEO4J_URL: @NEO4J_URL@
+
+# Redirect HTTP to HTTPS
+secure: always

--- a/Heroku/deploy/appengine/src/main/appengine/app.yaml
+++ b/Heroku/deploy/appengine/src/main/appengine/app.yaml
@@ -17,5 +17,8 @@ env_variables:
   # Used by endpoint and sync. URL of the Neo4J graph database server, including authentication details. e.g. neo4j+s://user:pass@host:1234",
   NEO4J_URL: @NEO4J_URL@
 
-# Redirect HTTP to HTTPS
-secure: always
+handlers:
+  - url: /.*
+    # Redirect HTTP to HTTPS
+    secure: always
+    redirect_http_response_code: 301

--- a/Heroku/deploy/appengine/src/main/appengine/app.yaml
+++ b/Heroku/deploy/appengine/src/main/appengine/app.yaml
@@ -22,3 +22,4 @@ handlers:
     # Redirect HTTP to HTTPS
     secure: always
     redirect_http_response_code: 301
+    script: auto

--- a/Heroku/deploy/appengine/src/main/appengine/app.yaml
+++ b/Heroku/deploy/appengine/src/main/appengine/app.yaml
@@ -6,8 +6,13 @@ automatic_scaling:
   max_instances: 1
 
 # `static` is a folder in the deployment directory, it's populated by :deploy:appengine:copyFrontendResources.
-entrypoint: java -Xmx64M -jar twisterrob-cinema-backend-endpoint.jar static
-  
+entrypoint: >
+  java
+  -Xmx64M
+  -jar twisterrob-cinema-backend-endpoint.jar
+  -P:twisterrob.cinema.environment=production
+  -P:twisterrob.cinema.staticRootFolder=static
+
 env_variables:
   # Used by endpoint and sync. URL of the Neo4J graph database server, including authentication details. e.g. neo4j+s://user:pass@host:1234",
   NEO4J_URL: @NEO4J_URL@

--- a/Heroku/package.json
+++ b/Heroku/package.json
@@ -20,7 +20,7 @@
 		"start:documentation": "Assumes: `cd frontend && npm run build:<env> && cd ..`",
 		"start": "gradlew :backend:endpoint:run",
 		"start:fake:documentation": "echo http://localhost:8080/planner?cineworldDate=&c=103&d=2017-07-14&f=160231&f=160454&f=184739&f=189108&f=223046",
-		"start:fake": "gradlew :backend:endpoint:run --args=\"../../deploy/frontend/static ../../test/fake-data\"",
+		"start:fake": "gradlew :backend:endpoint:run --args=\"-P:twisterrob.cinema.staticRootFolder=../../deploy/frontend/static -P:twisterrob.cinema.fakeRootFolder=../../test/fake-data\"",
 		"updateFromCineworld": "gradlew :backend:sync:run --args=\"cinemas films performances\"",
 		"updateFromCineworldFromTestFolder": "gradlew :backend:sync:run --args=\"cinemas films performances --folder=test\"",
 		"updateFromCineworldPerformances": "gradlew :backend:sync:run --args=\"performances\"",
@@ -32,7 +32,7 @@
 		"devTest": "npm-run-all --race --parallel devTest:*",
 		"devTest:selenium": "(cd test && npm run selenium && cd..)",
 		"devTest:frontend": "(cd frontend && npm start && cd ..)",
-		"devTest:backend": "gradlew :backend:endpoint:run --args=\"../../deploy/frontend/static ../../test/fake-data\""
+		"devTest:backend": "gradlew :backend:endpoint:run --args=\"-P:twisterrob.cinema.staticRootFolder=../../deploy/frontend/static -P:twisterrob.cinema.fakeRootFolder=../../test/fake-data\""
 	},
 	"devDependencies": {
 		"npm-run-all": "4.1.5"


### PR DESCRIPTION
Login fails with
![image](https://user-images.githubusercontent.com/2906988/206726894-d15e5ad9-ff63-4248-93ec-8b921e41689b.png)
because `redirect_uri=http://cinema.twisterrob.net:8081/auth/google/return`

This is because the external url is calculated incorrectly due to being in the wrong env:
```
[32m2022-12-09T13:03:48,153 INFO  [main] ktor.application(configuration.kt:73)[m [97mConfiguring app as DEVELOPMENT environment.[m
```

Solution: Fully reconfigure using HOCON + ktor built-in configurations and override environment in AppEngine.