### PR TITLE
Generate fewer performances

### DIFF
--- a/Heroku/backend/sync/src/main/kotlin/net/twisterrob/cinema/cineworld/generate/PerformanceGenerator.kt
+++ b/Heroku/backend/sync/src/main/kotlin/net/twisterrob/cinema/cineworld/generate/PerformanceGenerator.kt
@@ -103,7 +103,12 @@ class RandomPerformanceCreator @Inject constructor() {
 			}
 			.filter { random() < FUZZY_THRESHOLD }
 			.flatMap { (cinema, film, date) ->
-				val performanceCount = (random() * MAX_PERFORMANCES_IN_CINEMA).toInt()
+				val maxPerformanceCount =
+					if (cinema.name.startsWith("London - "))
+						MAX_PERFORMANCES_IN_LONDON_CINEMA
+					else
+						MAX_PERFORMANCES_IN_RURAL_CINEMA
+				val performanceCount = (random() * maxPerformanceCount).toInt()
 				(0..performanceCount).map { create(cinema, film, date) }
 			}
 	}
@@ -132,11 +137,12 @@ class RandomPerformanceCreator @Inject constructor() {
 
 	companion object {
 
-		/** Only 70% of the combinations will be populated so not all movies are screened in all cinemas. */
-		private const val FUZZY_THRESHOLD = 0.7
+		/** Only 60% of the combinations will be populated so not all movies are screened in all cinemas. */
+		private const val FUZZY_THRESHOLD = 0.6
 
 		/** It's a realistic value, screenings per movie per day in a specific cinema. */
-		private const val MAX_PERFORMANCES_IN_CINEMA = 5
+		private const val MAX_PERFORMANCES_IN_LONDON_CINEMA = 5
+		private const val MAX_PERFORMANCES_IN_RURAL_CINEMA = 2
 
 		private const val SCREENING_START_HOUR = 10
 		private const val SCREENING_END_HOUR = 21


### PR DESCRIPTION
https://github.com/TWiStErRob/net.twisterrob.cinema/actions/runs/3700743076

```
Error: Exception in thread "main" org.neo4j.ogm.exception.TransactionException: The allocation of an extra 2.0 MiB would use more than the limit 250.0 MiB. Currently using 249.0 MiB. dbms.memory.transaction.total.max threshold reached
	at org.neo4j.ogm.drivers.bolt.transaction.BoltTransaction.commit(BoltTransaction.java:111)
	at org.neo4j.ogm.session.Neo4jSession.doInTransaction(Neo4jSession.java:591)
	at org.neo4j.ogm.session.Neo4jSession.doInTransaction(Neo4jSession.java:563)
	at org.neo4j.ogm.session.delegates.ExecuteQueriesDelegate.query(ExecuteQueriesDelegate.java:145)
	at org.neo4j.ogm.session.Neo4jSession.query(Neo4jSession.java:434)
	at org.neo4j.ogm.session.Neo4jSession.query(Neo4jSession.java:424)
	at org.neo4j.ogm.session.delegates.DeleteDelegate.count(DeleteDelegate.java:289)
	at org.neo4j.ogm.session.delegates.DeleteDelegate.delete(DeleteDelegate.java:117)
	at org.neo4j.ogm.session.Neo4jSession.delete(Neo4jSession.java:469)
	at net.twisterrob.cinema.database.services.PerformanceService.deleteAll(PerformanceService.kt:55)
	at net.twisterrob.cinema.cineworld.sync.PerformanceSync.sync(PerformanceSync.kt:32)
	at net.twisterrob.cinema.cineworld.sync.Main.sync(Main.kt:29)
	at net.twisterrob.cinema.cineworld.sync.Main$Companion.main(Main.kt:49)
	at net.twisterrob.cinema.cineworld.sync.Main.main(Main.kt)
Caused by: org.neo4j.driver.exceptions.TransientException: The allocation of an extra 2.0 MiB would use more than the limit 250.0 MiB. Currently using 249.0 MiB. dbms.memory.transaction.total.max threshold reached
	at org.neo4j.driver.internal.util.Futures.blockingGet(Futures.java:111)
	at org.neo4j.driver.internal.InternalTransaction.commit(InternalTransaction.java:37)
	at org.neo4j.ogm.drivers.bolt.transaction.BoltTransaction.commit(BoltTransaction.java:96)
	... 13 more
	Suppressed: org.neo4j.driver.internal.util.ErrorUtil$InternalExceptionCause
		at org.neo4j.driver.internal.util.ErrorUtil.newNeo4jError(ErrorUtil.java:87)
		at org.neo4j.driver.internal.async.inbound.InboundMessageDispatcher.handleFailureMessage(InboundMessageDispatcher.java:107)
		at org.neo4j.driver.internal.messaging.common.CommonMessageReader.unpackFailureMessage(CommonMessageReader.java:75)
		at org.neo4j.driver.internal.messaging.common.CommonMessageReader.read(CommonMessageReader.java:53)
		at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:81)
		at org.neo4j.driver.internal.async.inbound.InboundMessageHandler.channelRead0(InboundMessageHandler.java:37)
		at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
		at org.neo4j.driver.internal.async.inbound.MessageDecoder.channelRead(MessageDecoder.java:42)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1373)
		at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1236)
		at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1285)
		at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
		at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
		at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
		at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
		at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
		at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
		at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:[65](https://github.com/TWiStErRob/net.twisterrob.cinema/actions/runs/3700743076/jobs/6269444896#step:7:66)0)
		at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
		at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:[74](https://github.com/TWiStErRob/net.twisterrob.cinema/actions/runs/3700743076/jobs/6269444896#step:7:75))
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Thread.java:[83](https://github.com/TWiStErRob/net.twisterrob.cinema/actions/runs/3700743076/jobs/6269444896#step:7:84)3)
```

Tried in Neo4J console too: `MATCH (p:Performance) DETACH DELETE p` doesn't work for 38000 items, but was able to recover via `MATCH (p:Performance) WHERE rand() < 0.5 DETACH DELETE p`. Changed amount of performances generated to make sure they're deletable at once.