### PR TITLE
Fail fast(er) if there's a problem in the runtime of map script

### DIFF
--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run map.main.kts.
         working-directory: map
-        run: kotlinc -script map.main.kts
+        run: kotlinc "-J--illegal-access=deny" -script map.main.kts
 
       - name: Upload "cinemas.kml" artifact.
         if: success() || failure()

--- a/map/map.main.kts
+++ b/map/map.main.kts
@@ -19,7 +19,7 @@
 // Override transitively included jaxb-impl:2.2 to avoid warning when marshalling Kml.
 // > Illegal reflective access by com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1 (jaxb-impl-2.2.jar)
 // > to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int)
-@file:DependsOn("com.sun.xml.bind:jaxb-impl:2.3.8")
+@file:DependsOn("com.sun.xml.bind:jaxb-impl:4.0.2")
 @file:DependsOn("de.micromata.jak:JavaAPIforKml:2.2.1")
 
 import com.fasterxml.jackson.databind.DeserializationFeature

--- a/map/map.main.kts
+++ b/map/map.main.kts
@@ -1,3 +1,5 @@
+//@file:RuntimeOptions("-J--illegal-access=deny")
+
 // Based on:
 // main.kts: https://kotlinlang.org/docs/custom-script-deps-tutorial.html
 // HttpClient: https://ktor.io/docs/http-client-engines.html#java

--- a/map/map.main.kts
+++ b/map/map.main.kts
@@ -19,7 +19,7 @@
 // Override transitively included jaxb-impl:2.2 to avoid warning when marshalling Kml.
 // > Illegal reflective access by com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1 (jaxb-impl-2.2.jar)
 // > to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int)
-@file:DependsOn("com.sun.xml.bind:jaxb-impl:4.0.2")
+@file:DependsOn("com.sun.xml.bind:jaxb-impl:2.3.8")
 @file:DependsOn("de.micromata.jak:JavaAPIforKml:2.2.1")
 
 import com.fasterxml.jackson.databind.DeserializationFeature


### PR DESCRIPTION
When jaxb is updated to later version #352 / #353 it shows:
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1 (file:/C:/Users/TWiStEr/.m2/repository/com/sun/xml/bind/jaxb-impl/2.2/jaxb-impl-2.2.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],
int,int)
WARNING: Please consider reporting this to the maintainers of com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
don't allow this, by explicitly failing, therefore preventing upgrade.