### PR TITLE
Disable AppEngine plugin markers in Renovate, because those artifacts don't exist

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,6 +44,18 @@
 			],
 			"matchUpdateTypes": ["major"],
 			"enabled": false
+		},
+		{
+			"description": "Disable these Gradle Plugin Markers, because they don't exist. The mapping from id(com.google.cloud.tools.appengine*) to com.google.cloud.tools:appengine-gradle-plugin is done in settings.gradle.kts.",
+			"matchPackageNames": [
+				"com.google.cloud.tools.appengine:com.google.cloud.tools.appengine.gradle.plugin",
+				"com.google.cloud.tools.appengine-appyaml:com.google.cloud.tools.appengine-appyaml.gradle.plugin",
+				"com.google.cloud.tools.appengine-appenginewebxml:com.google.cloud.tools.appengine-appenginewebxml.gradle.plugin"
+			],
+			"matchPaths": [
+				"Heroku/gradle/libs.versions.toml"
+			],
+			"enabled": false
 		}
 	]
 }

--- a/Heroku/gradle/libs.versions.toml
+++ b/Heroku/gradle/libs.versions.toml
@@ -157,5 +157,5 @@ log4j = ["log4j-api", "log4j-core", "log4j-slf4j"]
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-# From `com.google.cloud.tools:appengine-maven-plugin`
+# From `com.google.cloud.tools:appengine-gradle-plugin`
 appengine-yaml = { id = "com.google.cloud.tools.appengine-appyaml", version.ref = "appengine" }


### PR DESCRIPTION
Fixes
![image](https://github.com/TWiStErRob/net.twisterrob.cinema/assets/2906988/c4b23a42-77ab-4c10-9ef0-690bac033c8e)

See #406 at 2023-06-16 state.