### PR TITLE
Fix warnings and color logs

### DIFF
--- a/planner/backend/endpoint/build.gradle.kts
+++ b/planner/backend/endpoint/build.gradle.kts
@@ -7,7 +7,8 @@ application {
 	mainClass = "io.ktor.server.netty.EngineMain"
 	tasks.named<JavaExec>("run") {
 		jvmArgs(
-			"-Dlog4j.configurationFile=log4j2.xml,log4j2-endpoint.xml"
+			"-Dlog4j.configurationFile=log4j2.xml,log4j2-endpoint.xml",
+			"-Dlog4j2.skipJansi=false",
 		)
 		// Can be overridden with `gradlew :backend:endpoint:run --args="-P:twisterrob.cinema.staticRootFolder=<static-folder> -P:twisterrob.cinema.fakeRootFolder=<fake-folder>"`.
 		args(

--- a/planner/backend/sync/build.gradle.kts
+++ b/planner/backend/sync/build.gradle.kts
@@ -5,11 +5,13 @@ plugins {
 application {
 	mainClass = "net.twisterrob.cinema.cineworld.sync.Main"
 	tasks.named<JavaExec>("run") {
+		val configFiles = if (project.property("net.twisterrob.run.verboseSync").toString().toBoolean())
+			"log4j2.xml"
+		else
+			"log4j2.xml,log4j2-sync.xml"
 		jvmArgs(
-			if (project.property("net.twisterrob.run.verboseSync").toString().toBoolean())
-				"-Dlog4j.configurationFile=log4j2.xml"
-			else
-				"-Dlog4j.configurationFile=log4j2.xml,log4j2-sync.xml"
+			"-Dlog4j.configurationFile=${configFiles}",
+			"-Dlog4j2.skipJansi=false",
 		)
 		// Can be overridden with `gradlew :backend:sync:run --args="<sync-type...>"`.
 		args(

--- a/planner/config/log4j2.xml
+++ b/planner/config/log4j2.xml
@@ -15,7 +15,7 @@
 		<!-- See org.apache.logging.log4j.core.pattern.AnsiEscape for keywords  -->
 		<!-- %highlight separates keywords by spaces, %style separates keywords by commas! -->
 		<Property name="pattern_level_colors">
-			FATAL=bright magenta, ERROR=bright red, WARN=bright yellow, INFO=dim white, DEBUG=bright black, TRACE=cyan
+			FATAL=bright_magenta, ERROR=bright_red, WARN=bright_yellow, INFO=dim white, DEBUG=bright_black, TRACE=cyan
 		</Property>
 		<!-- Whitespace within color configuration (highlight/style) will be ignored -->
 		<Property name="pattern_styled">%highlight{%date{ISO8601} %-5level [%thread] %logger(%file:%line)}{

--- a/planner/config/log4j2.xml
+++ b/planner/config/log4j2.xml
@@ -18,8 +18,8 @@
 			FATAL=bright magenta, ERROR=bright red, WARN=bright yellow, INFO=dim white, DEBUG=bright black, TRACE=cyan
 		</Property>
 		<!-- Whitespace within color configuration (highlight/style) will be ignored -->
-		<Property name="pattern_styled">%highlight{%date{ISO8601} %-5level [%thread] %logger(%file:%line)}{${
-		pattern_level_colors}} %style{%message}{bright_white}%n%style{%throwable}{BG_red,white}
+		<Property name="pattern_styled">%highlight{%date{ISO8601} %-5level [%thread] %logger(%file:%line)}{
+			${pattern_level_colors}} %style{%message}{bright_white}%n%style{%throwable}{BG_red,white}
 		</Property>
 	</Properties>
 

--- a/planner/config/log4j2.xml
+++ b/planner/config/log4j2.xml
@@ -182,6 +182,13 @@
 			DEBUG (ByteBufUtil.java:98) -Dio.netty.maxThreadLocalCharBufferSize: 16384
 		-->
 		<Logger name="io.netty" level="INFO" />
+		
+		<!-- on test startup, repeated many times and many others
+			DEBUG org.eclipse.jetty.util.component.ContainerLifeCycle(ContainerLifeCycle.java:419) org.eclipse.jetty.server.session.SessionHandler1378287256==dftMaxIdleSec=-1 added {ConstraintSecurityHandler@6722f78d{STOPPED},MANAGED}
+			DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool(QueuedThreadPool.java:863) Starting Thread[qtp2105949564-59,5,main]
+			DEBUG org.eclipse.jetty.util.thread.QueuedThreadPool(QueuedThreadPool.java:1131) Runner started for QueuedThreadPool[qtp2105949564]@7d863d7c{STARTING,15<=6<=33,i=6,r=-1,t=59999ms,q=0}[ReservedThreadExecutor@7cd7e3c0{reserved=0/3,pending=0}]
+		-->
+		<Logger name="org.eclipse.jetty" level="WARN" />
 
 	</Loggers>
 

--- a/planner/gradle/libs.versions.toml
+++ b/planner/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ jackson-databind = "2.18.1"
 
 slf4j = "2.0.16"
 log4j = "2.24.1"
+jansi = "2.4.0"
 
 test-junit-vintage = "4.13.2"
 test-junit-jupiter = "5.11.3"
@@ -126,6 +127,7 @@ log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4
 # See https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html
 log4j-slf4j = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
 log4j-jul = { module = "org.apache.logging.log4j:log4j-jul", version.ref = "log4j" }
+jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 
 test-selenium = { module = "org.seleniumhq.selenium:selenium-java", version.ref = "test-selenium" }
 test-selenium-angular = { module = "com.paulhammant:ngwebdriver", version.ref = "test-ngWebDriver" }

--- a/planner/gradle/plugins/src/main/kotlin/Deps.kt
+++ b/planner/gradle/plugins/src/main/kotlin/Deps.kt
@@ -25,6 +25,7 @@ object Deps {
 		project.dependencies {
 			add("implementation", project.libs.slf4j.core)
 			add("runtimeOnly", project.libs.bundles.log4j)
+			add("runtimeOnly", project.libs.jansi)
 		}
 	}
 

--- a/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
+++ b/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
@@ -27,6 +27,17 @@ kotlin.target.compilations.named("testFixtures") {
 @Suppress("UnstableApiUsage")
 testing {
 	suites {
+		withType<JvmTestSuite>().configureEach {
+			targets.configureEach {
+				testTask.configure {
+					jvmArgs(
+						// Reduce occurrences of warning:
+						// > Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
+						"-Xshare:off",
+					)
+				}
+			}
+		}
 		withType<JvmTestSuite>().named { it != JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME }.configureEach {
 			useJUnitJupiter(libs.versions.test.junit.jupiter)
 			conventionalSetup(configurations)

--- a/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
+++ b/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
@@ -35,6 +35,9 @@ testing {
 						// > Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
 						"-Xshare:off",
 					)
+					// Ensure pattern_level_colors get applied from log4j2.xml.
+					// See https://logging.apache.org/log4j/2.x/manual/pattern-layout.html#jansi
+					systemProperty("log4j2.skipJansi", "false")
 				}
 			}
 		}

--- a/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
+++ b/planner/gradle/plugins/src/main/kotlin/net/twisterrob/cinema/build/testing.gradle.kts
@@ -89,6 +89,15 @@ testing {
 					shouldRunAfter(unitTest, functionalTest)
 				}
 			}
+			configurations.named(sources.runtimeClasspathConfigurationName).configure {
+				// Prevent Neo4J stealing log output:
+				// > SLF4J(W): Class path contains multiple SLF4J providers.
+				// > SLF4J(W): Found provider [org.neo4j.server.logging.slf4j.SLF4JLogBridge@6f576b33]
+				// > SLF4J(W): Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@541f03d7]
+				// > SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+				// > SLF4J(I): Actual provider is of type [org.neo4j.server.logging.slf4j.SLF4JLogBridge@6f576b33]
+				exclude("org.neo4j", "neo4j-slf4j-provider")
+			}
 		}
 
 		/**

--- a/planner/settings.gradle.kts
+++ b/planner/settings.gradle.kts
@@ -1,5 +1,3 @@
-import net.twisterrob.cinema.build.dsl.isCI
-import net.twisterrob.gradle.doNotNagAbout
 import net.twisterrob.gradle.settings.enableFeaturePreviewQuietly
 
 rootProject.name = "net-twisterrob-cinema-planner"
@@ -54,59 +52,4 @@ buildscript {
 		lockAllConfigurations()
 		lockFile = file("gradle/dependency-locks/root-settings.lockfile")
 	}
-}
-
-val gradleVersion: String = GradleVersion.current().version
-
-// TODEL Gradle 8.2 sync in IDEA 2023.1 https://youtrack.jetbrains.com/issue/IDEA-320266.
-@Suppress("MaxLineLength", "StringLiteralDuplication")
-if ((System.getProperty("idea.version") ?: "") < "2023.2") {
-	// There are ton of warnings, ignoring them all by their class names in one suppression.
-	doNotNagAbout(
-		Regex(
-			"^" +
-					"(" +
-					Regex.escape("The Project.getConvention() method has been deprecated. ") +
-					"|" +
-					Regex.escape("The org.gradle.api.plugins.Convention type has been deprecated. ") +
-					"|" +
-					Regex.escape("The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. ") +
-					")" +
-					Regex.escape("This is scheduled to be removed in Gradle 9.0. ") +
-					Regex.escape("Consult the upgrading guide for further information: ") +
-					Regex.escape("https://docs.gradle.org/${gradleVersion}/userguide/upgrading_version_8.html#") +
-					".*" +
-					"(" +
-					Regex.escape("at org.jetbrains.kotlin.idea.gradleTooling.KotlinTasksPropertyUtilsKt.") +
-					"|" +
-					Regex.escape("at org.jetbrains.plugins.gradle.tooling.util.JavaPluginUtil.") +
-					"|" +
-					Regex.escape("at org.jetbrains.plugins.gradle.tooling.builder.ExternalProjectBuilderImpl.") +
-					"|" +
-					Regex.escape("at org.jetbrains.plugins.gradle.tooling.builder.ProjectExtensionsDataBuilderImpl.") +
-					")" +
-					".*$"
-		)
-	)
-} else {
-	val error: (String) -> Unit = if (isCI) ::error else logger::warn
-	error("IDEA version changed, please review hack.")
-}
-
-// TODEL Gradle 8.2 sync in IDEA 2023.1 https://youtrack.jetbrains.com/issue/IDEA-320307.
-@Suppress("MaxLineLength", "StringLiteralDuplication")
-if ((System.getProperty("idea.version") ?: "") < "2023.2") {
-	@Suppress("MaxLineLength", "StringLiteralDuplication")
-	doNotNagAbout(
-		"The BuildIdentifier.getName() method has been deprecated. " +
-				"This is scheduled to be removed in Gradle 9.0. " +
-				"Use getBuildPath() to get a unique identifier for the build. " +
-				"Consult the upgrading guide for further information: " +
-				"https://docs.gradle.org/${gradleVersion}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-		// There are 4 stack traces coming to this line, ignore them all at once.
-		"at org.jetbrains.plugins.gradle.tooling.util.resolve.DependencyResolverImpl.resolveDependencies(DependencyResolverImpl.java:266)"
-	)
-} else {
-	val error: (String) -> Unit = if (isCI) ::error else logger::warn
-	error("IDEA version changed, please review hack.")
 }


### PR DESCRIPTION
> Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> 2024-10-29T23:05:59.625788800Z ForkJoinPool-1-worker-1 WARN Syntax error, missing '=': Expected "{KEY1=VALUE, KEY2=VALUE, ...}
