### PR TITLE
Ignore "Slow network detected" log line in UI tests

### DIFF
--- a/planner/test-integration/build.gradle.kts
+++ b/planner/test-integration/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 	Deps.junit5(project)
 	Deps.slf4jToLog4jForTest(project, testType = "integrationExternalTest")
 	integrationExternalTestImplementation(projects.testHelpers)
+	integrationExternalTestImplementation(libs.test.mockito.kotlin)
 
 	implementation(libs.test.assertj)
 	implementation(libs.test.selenium)

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/BrowserExtension.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/BrowserExtension.kt
@@ -1,6 +1,5 @@
 package net.twisterrob.cinema.frontend.test.framework
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -10,7 +9,6 @@ import org.junit.jupiter.api.extension.ParameterResolver
 import org.openqa.selenium.OutputType
 import org.openqa.selenium.TakesScreenshot
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.logging.LogType
 import java.io.File
 
 // TODO rewrite using https://bonigarcia.dev/selenium-jupiter/
@@ -87,30 +85,6 @@ class BrowserExtension : BeforeEachCallback, AfterEachCallback, AfterTestExecuti
 				.filter { BasePage::class.java.isAssignableFrom(it.type) }
 				.onEach { it.isAccessible = true }
 				.forEach { it.set(instance, it.type.getConstructor(BROWSER_VALUE_TYPE).newInstance(browser)) }
-		}
-
-		/**
-		 * Grab logs from Chrome console at the end of the test, so we can make sure there are no problems:
-		 *  * Chrome deprecations
-		 *  * JavaScript errors
-		 *  * JavaScript warnings
-		 *  * Angular deprecations
-		 *  * Leftover console.log() calls
-		 *  * etc.
-		 */
-		private fun WebDriver.verifyLogs() {
-			// JavaScript running in the browser: console.log("hello");
-			// Results in the following output to driver logs:
-			// > [1690997212.256][DEBUG]: DevTools WebSocket Event: Runtime.consoleAPICalled (session_id=...) ... {
-			// >   "args": [ {
-			// >     "type": "string",
-			// >     "value": "hello"
-			// >   } ],
-			// >   "executionContextId": 1,
-			// >   "stackTrace": { ... }
-			val logs = manage().logs().get(LogType.BROWSER).all
-			logs.forEach(LogPrinter()::print)
-			assertThat(logs).isEmpty()
 		}
 
 		private fun WebDriver.takeScreenshot(testHierarchy: List<String>): File {

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
@@ -27,9 +27,10 @@ internal fun WebDriver.verifyLogs(log: (LogEntry) -> Unit = LogPrinter()::print)
 	// >   "stackTrace": { ... }
 	val logs = manage().logs().get(LogType.BROWSER).all
 	val filteredLogs = logs
-		.filterNot {
+		.filterNot { entry ->
 			// See https://www.chromestatus.com/feature/5636954674692096 for more details.
-			it.level == Level.INFO && it.message.matches(Regex(""".*Slow network is detected\. .*Fallback font will be used while loading:.*$"""))
+			val slowNetwork = Regex(""".*Slow network is detected\. .*Fallback font will be used while loading:.*$""")
+			entry.level == Level.INFO && entry.message.matches(slowNetwork)
 		}
 	logs.forEach(log)
 	assertThat(filteredLogs).isEmpty()

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
@@ -29,8 +29,8 @@ internal fun WebDriver.verifyLogs(log: (LogEntry) -> Unit = LogPrinter()::print)
 	val filteredLogs = logs
 		.filterNot {
 			// See https://www.chromestatus.com/feature/5636954674692096 for more details.
-			it.level == Level.INFO && it.message.matches(Regex("""Slow network is detected\. .*Fallback font will be used while loading"""))
+			it.level == Level.INFO && it.message.matches(Regex(""".*Slow network is detected\. .*Fallback font will be used while loading:.*$"""))
 		}
 	logs.forEach(log)
-	assertThat(logs).isEmpty()
+	assertThat(filteredLogs).isEmpty()
 }

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogs.kt
@@ -1,0 +1,36 @@
+package net.twisterrob.cinema.frontend.test.framework
+
+import org.assertj.core.api.Assertions.assertThat
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.logging.LogEntry
+import org.openqa.selenium.logging.LogType
+import java.util.logging.Level
+
+/**
+ * Grab logs from Chrome console at the end of the test, so we can make sure there are no problems:
+ *  * Chrome deprecations
+ *  * JavaScript errors
+ *  * JavaScript warnings
+ *  * Angular deprecations
+ *  * Leftover console.log() calls
+ *  * etc.
+ */
+internal fun WebDriver.verifyLogs(log: (LogEntry) -> Unit = LogPrinter()::print) {
+	// JavaScript running in the browser: console.log("hello");
+	// Results in the following output to driver logs:
+	// > [1690997212.256][DEBUG]: DevTools WebSocket Event: Runtime.consoleAPICalled (session_id=...) ... {
+	// >   "args": [ {
+	// >     "type": "string",
+	// >     "value": "hello"
+	// >   } ],
+	// >   "executionContextId": 1,
+	// >   "stackTrace": { ... }
+	val logs = manage().logs().get(LogType.BROWSER).all
+	val filteredLogs = logs
+		.filterNot {
+			// See https://www.chromestatus.com/feature/5636954674692096 for more details.
+			it.level == Level.INFO && it.message.matches(Regex("""Slow network is detected\. .*Fallback font will be used while loading"""))
+		}
+	logs.forEach(log)
+	assertThat(logs).isEmpty()
+}

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogsKtTest.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogsKtTest.kt
@@ -28,6 +28,7 @@ import kotlin.uuid.Uuid
 
 private val NL: String = System.lineSeparator()
 
+@Suppress("detekt.ClassNaming")
 class WebDriver_verifyLogsKtTest {
 
 	@Test fun `no logs pass and print nothing`() {

--- a/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogsKtTest.kt
+++ b/planner/test-integration/src/integrationExternalTest/kotlin/net/twisterrob/cinema/frontend/test/framework/WebDriver_verifyLogsKtTest.kt
@@ -1,0 +1,125 @@
+package net.twisterrob.cinema.frontend.test.framework
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.support.ParameterDeclarations
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.logging.LogEntries
+import org.openqa.selenium.logging.LogEntry
+import org.openqa.selenium.logging.LogType
+import org.openqa.selenium.logging.Logs
+import java.util.logging.Level
+import java.util.stream.Stream
+import kotlin.random.Random
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class WebDriver_verifyLogsKtTest {
+
+	@Test fun `no logs pass and print nothing`() {
+		val driver: WebDriver = fakeDriverWithLogs()
+
+		val log: (LogEntry) -> Unit = mock()
+		driver.verifyLogs(log)
+
+		verifyNoInteractions(log)
+	}
+
+	@ArgumentsSource(JULLevelProvider::class)
+	@ParameterizedTest
+	fun `single log fails regardless of level`(level: Level) {
+		val log1 = entry(level)
+		val driver: WebDriver = fakeDriverWithLogs(log1)
+
+		val log: (LogEntry) -> Unit = mock()
+		assertThrows<AssertionError> { driver.verifyLogs(log) }
+
+		verify(log).invoke(log1)
+		verifyNoMoreInteractions(log)
+	}
+
+	@Test
+	fun `multiple logs fail`() {
+		val log1 = entry()
+		val log2 = entry()
+		val log3 = entry()
+		val driver: WebDriver = fakeDriverWithLogs(log1, log2, log3)
+
+		val log: (LogEntry) -> Unit = mock()
+		assertThrows<AssertionError> { driver.verifyLogs(log) }
+
+		inOrder(log) {
+			verify(log).invoke(log1)
+			verify(log).invoke(log2)
+			verify(log).invoke(log3)
+			verifyNoMoreInteractions()
+		}
+	}
+
+	@Test
+	fun `slow network log is ignored`() {
+		val slowNetwork = LogEntry(
+			Level.INFO,
+			Random.nextLong(),
+			"http://127.0.0.1:8080/planner/index.bundle.js " +
+					"5286 Slow network is detected. " +
+					"See https://www.chromestatus.com/feature/5636954674692096 for more details. " +
+					"Fallback font will be used while loading: " +
+					"http://127.0.0.1:8080/fonts/glyphicons-halflings-regular-be810be3a3e14c682a25.woff2"
+		)
+		val log1 = entry()
+		val log2 = entry()
+		val driver: WebDriver = fakeDriverWithLogs(log1, slowNetwork, log2)
+
+		val log: (LogEntry) -> Unit = mock()
+		assertThrows<AssertionError> { driver.verifyLogs(log) }
+
+		inOrder(log) {
+			verify(log).invoke(log1)
+			verify(log).invoke(log2)
+			verifyNoMoreInteractions()
+		}
+	}
+}
+
+private fun entry(level: Level = Level.WARNING): LogEntry =
+	@OptIn(ExperimentalUuidApi::class)
+	LogEntry(level, Random.nextLong(), Uuid.random().toString())
+
+private fun fakeDriverWithLogs(vararg logs: LogEntry): WebDriver {
+	val logEntries = LogEntries(logs.toList())
+	val mockDriver: WebDriver = mock()
+	val mockOptions: WebDriver.Options = mock()
+	val mockLogs: Logs = mock()
+	whenever(mockDriver.manage()).thenReturn(mockOptions)
+	whenever(mockDriver.manage().logs()).thenReturn(mockLogs)
+	whenever(mockDriver.manage().logs().get(LogType.BROWSER)).thenReturn(logEntries)
+	return mockDriver
+}
+
+private class JULLevelProvider : ArgumentsProvider {
+
+	override fun provideArguments(parameters: ParameterDeclarations, context: ExtensionContext): Stream<out Arguments> =
+		Stream.of(
+			Level.OFF,
+			Level.SEVERE,
+			Level.WARNING,
+			Level.INFO,
+			Level.CONFIG,
+			Level.FINE,
+			Level.FINER,
+			Level.FINEST,
+			Level.ALL
+		).map { Arguments.of(it) }
+}


### PR DESCRIPTION
<img width="1240" height="417" alt="image" src="https://github.com/user-attachments/assets/a0e1bf8c-9bcd-4940-95a3-e2ed0fd1dcb1" />

```
java.lang.AssertionError: 
Expecting empty but was: [[2025-09-29T21:06:11.329Z] [INFO] http://127.0.0.1:8080/planner/index.bundle.js 5286 Slow network is detected. See https://www.chromestatus.com/feature/5636954674692096 for more details. Fallback font will be used while loading: http://127.0.0.1:8080/fonts/glyphicons-halflings-regular-be810be3a3e14c682a25.woff2]
	at net.twisterrob.cinema.frontend.test.framework.BrowserExtension$Companion.verifyLogs(BrowserExtension.kt:113)
	at net.twisterrob.cinema.frontend.test.framework.BrowserExtension$Companion.access$verifyLogs(BrowserExtension.kt:57)
	at net.twisterrob.cinema.frontend.test.framework.BrowserExtension.afterEach(BrowserExtension.kt:44)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```